### PR TITLE
docs: add project management README (docs/README.md)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,19 @@
+# OctoAcme Project Management Docs — README
+
+This README provides a concise introduction to OctoAcme's project management processes and quick links to the process documentation in this folder. Use this file as an onboarding aid and a single place to discover the project's planning, execution, release, and continuous improvement guidance.
+
+OctoAcme follows an artifact-driven lifecycle that moves work from lightweight initiation through planning, execution, release, and retrospectives. Initiatives begin with a Project One-pager that defines the problem, objective, measurable success criteria, stakeholders, and a high-level timeline. Planning turns approved initiatives into prioritized, estimated backlogs, a Definition of Done, and a release/milestone map to guide delivery.
+
+Day-to-day execution is managed via an explicit project board workflow (Backlog → Ready → In Progress → In Review → QA → Done), small pull requests with linked issues and acceptance criteria, and a CI gate that runs tests and security scans before review. Roles are defined clearly: Product Managers set outcomes and prioritize the backlog, Project Managers coordinate delivery and communications, Developers implement and test, and QA validates acceptance. Regular team rhythm (standups, delivery syncs, demos) and stakeholder updates ensure alignment and transparency.
+
+Quality assurance is layered and automated where possible — unit and integration tests, end‑to‑end smoke tests for critical flows, and security scanning in CI — with manual QA used when human validation is required. Continuous improvement is embedded through regular retrospectives, tracked action items that feed back into the backlog, and measurement of success metrics identified in the Project One-pager.
+
+Process Document Links
+- docs/octoacme-project-management-overview.md
+- docs/octoacme-project-initiation.md
+- docs/octoacme-project-planning.md
+- docs/octoacme-execution-and-tracking.md
+- docs/octoacme-risks-and-communication.md
+- docs/octoacme-release-and-deployment.md
+- docs/octoacme-retrospective-and-continuous-improvement.md
+- docs/octoacme-roles-and-personas.md


### PR DESCRIPTION
This PR adds a README to docs/ that provides a short summary of OctoAcme's project management processes and links to the existing process documentation.
Purpose: centralize process discovery for onboarding and maintain a single entry point to the docs folder.
Changes: adds docs/README.md
References: Refs #2
Reviewers requested: @ajoluvya 